### PR TITLE
[ENH] Add functions for renaming files from csvs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ jobs:
          paths:
            - /tmp/cache/docker.tar.gz
 
-
   setup_conda:
     machine:
       image: ubuntu-1604:202004-01
@@ -97,7 +96,7 @@ jobs:
       - run:
           name: Download Singularity
           command: |
-            if [ ! -f /usr/local/bin/singularity ]
+            if [ ! -f /home/circleci/singularity.tar.gz ]
             then
               sudo apt-get update && sudo apt-get -y install build-essential \
                 libssl-dev \
@@ -126,7 +125,6 @@ jobs:
          paths:
             - /home/circleci/singularity.tar.gz
             - /home/circleci/go.tar.gz
-
 
   install_and_test_singularity:
     machine:
@@ -196,8 +194,6 @@ jobs:
               /tmp/bids/singularity \
               /tmp/group_testing/direct \
               --container /home/circleci/bond-latest.sif
-
-
 
   install_and_test:
     machine:

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,7 @@
 Dockerfile
 .DS_Store
 .gitignore
+notebooks
+tests
+docs
+

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import datalad.api as dlapi
 from tqdm import tqdm
-import subprocess
+import os
 
 bids.config.set_option('extension_initial_dot', True)
 
@@ -37,8 +37,8 @@ class BOnD(object):
         self.fieldmaps_cached = False
         self.datalad_ready = False
         self.datalad_handle = None
-        self.old_filenames = [] # files whose key groups changed
-        self.new_filenames = [] # new filenames for files to change
+        self.old_filenames = []  # files whose key groups changed
+        self.new_filenames = []  # new filenames for files to change
 
         # Initialize datalad if
         if use_datalad:
@@ -166,7 +166,7 @@ class BOnD(object):
             for old, new in zip(self.old_filenames, self.new_filenames):
                 exe_script.write("mv %s %s\n" % (old, new))
 
-        subprocess.run("datalad run -m 'apply csv' bash change_files.sh")
+        os.system("datalad run -m 'apply csv' 'change_files.sh'")
 
         return self.old_filenames, self.new_filenames
 
@@ -334,7 +334,8 @@ class BOnD(object):
                                  ignore_index=True))
 
         # create new col that strings key and param group together
-        summary["KeyParamGroup"] = summary["KeyGroup"] + '__' + summary["ParamGroup"].map(str)
+        summary["KeyParamGroup"] = summary["KeyGroup"] \
+            + '__' + summary["ParamGroup"].map(str)
 
         # move this column to the front of the dataframe
         key_param_col = summary.pop("KeyParamGroup")

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -418,6 +418,9 @@ class BOnD(object):
                 # write out
                 _update_json(json_file.path, sidecar)
 
+    def apply_csv_changes(self, previous_output_prefix, new_output_prefix):
+        pass
+
 
 def _update_json(json_file, metadata):
 

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -10,7 +10,6 @@ import numpy as np
 import pandas as pd
 import datalad.api as dlapi
 from tqdm import tqdm
-import subprocess
 
 bids.config.set_option('extension_initial_dot', True)
 
@@ -478,7 +477,6 @@ class BOnD(object):
                 # write out
                 _update_json(json_file.path, sidecar)
 
-
     def apply_csv_changes(self, previous_output_prefix, new_output_prefix):
         pass
 
@@ -512,14 +510,12 @@ class BOnD(object):
                 json.dump(metadata, jsonr, indent=4)
 
 
-
 def _update_json(json_file, metadata):
 
     if _validateJSON(metadata):
         with open(json_file, 'w', encoding='utf-8') as f:
             json.dump(metadata, f, ensure_ascii=False, indent=4)
     else:
-
         print("INVALID JSON DATA")
 
 

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -341,7 +341,15 @@ class BOnD(object):
 
         # move this column to the front of the dataframe
         key_param_col = summary.pop("KeyParamGroup")
-        summary.insert(0, "keyParamGroup", key_param_col)
+        summary.insert(0, "KeyParamGroup", key_param_col)
+
+        # do the same for the files df
+        big_df["KeyParamGroup"] = big_df["KeyGroup"] \
+            + '__' + big_df["ParamGroup"].map(str)
+
+        # move this column to the front of the dataframe
+        key_param_col = big_df.pop("KeyParamGroup")
+        big_df.insert(0, "KeyParamGroup", key_param_col)
 
         summary.insert(0, "RenameKeyGroup", np.nan)
         summary.insert(0, "MergeInto", np.nan)

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -159,8 +159,14 @@ class BOnD(object):
         # TODO: THROW AN EXCEPTION IF NEW_KEY NOT VALID!
         # OR IF KEY CAN'T BE PARSED AS A DICT?
 
-        self.layout = bids.BIDSLayout(self.path, validate=False)
-        self.get_CSVs(new_csv_dir)
+        # self.layout = bids.BIDSLayout(self.path, validate=False)
+        # self.get_CSVs(new_csv_dir)
+
+        with open("/Users/scovitz/BOnD/change_files.sh", "w") as exe_script:
+            for old, new in zip(self.old_filenames, self.new_filenames):
+                exe_script.write("mv %s %s\n" % (old, new))
+
+        subprocess.run("datalad run -m 'apply csv' bash change_files.sh")
 
         return self.old_filenames, self.new_filenames
 
@@ -358,10 +364,8 @@ class BOnD(object):
 
         big_df, summary = self.get_param_groups_dataframes()
 
-        big_df.to_csv(path_prefix + "_files.csv", index=False)
-        summary.to_csv(path_prefix + "_summary.csv", index=False)
-
-        return("AM I HERE")
+        big_df.to_csv(path_prefix + "files.csv", index=False)
+        summary.to_csv(path_prefix + "summary.csv", index=False)
 
     def get_file_params(self, key_group):
         key_entities = _key_group_to_entities(key_group)

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 import datalad.api as dlapi
 from tqdm import tqdm
-import os
+import subprocess
 
 bids.config.set_option('extension_initial_dot', True)
 
@@ -162,13 +162,15 @@ class BOnD(object):
         # self.layout = bids.BIDSLayout(self.path, validate=False)
         # self.get_CSVs(new_csv_dir)
 
-        with open("/Users/scovitz/BOnD/change_files.sh", "w") as exe_script:
+        with open("/Users/scovitz/BOnD/bond/change_files.sh", "w") \
+                as exe_script:
             for old, new in zip(self.old_filenames, self.new_filenames):
                 exe_script.write("mv %s %s\n" % (old, new))
 
-        os.system("datalad run -m 'apply csv' 'change_files.sh'")
+        my_proc = subprocess.run(
+            ['bash', '/Users/scovitz/BOnD/bond/change_files.sh'])
 
-        return self.old_filenames, self.new_filenames
+        return my_proc
 
     def change_filename(self, filepath, entities):
 

--- a/notebooks/Key_and_Param_Groups.ipynb
+++ b/notebooks/Key_and_Param_Groups.ipynb
@@ -38,9 +38,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: \"datalad run -m 'apply csv' bash change_files.sh\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-7340da032bab>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0mbod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mBOnD\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_root2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 8\u001b[0;31m \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mchange_key_groups\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'/Users/scovitz/BOnD/notebooks/NewTests/'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'/Users/scovitz/BOnD/notebooks/newCSVs/'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/BOnD/bond/bond.py\u001b[0m in \u001b[0;36mchange_key_groups\u001b[0;34m(self, og_csv_dir, new_csv_dir)\u001b[0m\n\u001b[1;32m    167\u001b[0m                 \u001b[0mexe_script\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"mv %s %s\\n\"\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mold\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnew\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    168\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 169\u001b[0;31m         \u001b[0msubprocess\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"datalad run -m 'apply csv' bash change_files.sh\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    170\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    171\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mold_filenames\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnew_filenames\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/miniconda3/lib/python3.8/subprocess.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(input, capture_output, timeout, check, *popenargs, **kwargs)\u001b[0m\n\u001b[1;32m    487\u001b[0m         \u001b[0mkwargs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'stderr'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mPIPE\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    488\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 489\u001b[0;31m     \u001b[0;32mwith\u001b[0m \u001b[0mPopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mpopenargs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mprocess\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    490\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    491\u001b[0m             \u001b[0mstdout\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstderr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mprocess\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcommunicate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/miniconda3/lib/python3.8/subprocess.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, args, bufsize, executable, stdin, stdout, stderr, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags, restore_signals, start_new_session, pass_fds, encoding, errors, text)\u001b[0m\n\u001b[1;32m    852\u001b[0m                             encoding=encoding, errors=errors)\n\u001b[1;32m    853\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 854\u001b[0;31m             self._execute_child(args, executable, preexec_fn, close_fds,\n\u001b[0m\u001b[1;32m    855\u001b[0m                                 \u001b[0mpass_fds\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcwd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0menv\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    856\u001b[0m                                 \u001b[0mstartupinfo\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcreationflags\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mshell\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/miniconda3/lib/python3.8/subprocess.py\u001b[0m in \u001b[0;36m_execute_child\u001b[0;34m(self, args, executable, preexec_fn, close_fds, pass_fds, cwd, env, startupinfo, creationflags, shell, p2cread, p2cwrite, c2pread, c2pwrite, errread, errwrite, restore_signals, start_new_session)\u001b[0m\n\u001b[1;32m   1700\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0merrno_num\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1701\u001b[0m                         \u001b[0merr_msg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstrerror\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merrno_num\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1702\u001b[0;31m                     \u001b[0;32mraise\u001b[0m \u001b[0mchild_exception_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merrno_num\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merr_msg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merr_filename\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1703\u001b[0m                 \u001b[0;32mraise\u001b[0m \u001b[0mchild_exception_type\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merr_msg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1704\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: \"datalad run -m 'apply csv' bash change_files.sh\""
+     ]
+    }
+   ],
    "source": [
     "###############################\n",
     "# TESTING change_key_groups!!!!\n",
@@ -76,23 +92,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 6/6 [00:00<00:00, 278.28it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "# generating csvs\n",
     "\n",
     "bod = BOnD(data_root2)\n",
-    "bod._cache_fieldmaps()\n",
     "out = bod.get_CSVs('/Users/scovitz/BOnD/notebooks/NewTests/')\n",
     "out"
    ]

--- a/notebooks/Key_and_Param_Groups.ipynb
+++ b/notebooks/Key_and_Param_Groups.ipynb
@@ -14,9 +14,11 @@
     "from pathlib import Path\n",
     "import csv\n",
     "import pandas as pd\n",
+    "import numpy as np\n",
     "#sys.path.append(\"..\")\n",
     "import os\n",
     "#import pytest\n",
+    "\n",
     "from pkg_resources import resource_filename as pkgrf\n",
     "from bond import BOnD\n",
     "#import shutil\n",
@@ -29,17 +31,75 @@
     "\n",
     "TEST_DATA = pkgrf(\"bond\", \"testdata\")\n",
     "\n",
-    "\n",
     "#data_root = Path(\".\") / \"testdata\" / \"complete\"\n",
     "\n",
-    "data_root2 = \"/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/\"\n",
-    "\n",
-    "#shutil.copytree(TEST_DATA, str(data_root))"
+    "data_root2 = \"/Users/scovitz/BOnD/bond/Testdata/complete/\"\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###############################\n",
+    "# TESTING change_key_groups!!!!\n",
+    "###############################\n",
+    "\n",
+    "\n",
+    "bod = BOnD(data_root2)\n",
+    "\n",
+    "out = bod.change_key_groups('/Users/scovitz/BOnD/notebooks/NewTests/', '/Users/scovitz/BOnD/notebooks/newCSVs/')\n",
+    "\n",
+    "\n",
+    "print(out)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# UNDOING RENAMING OF FILES \n",
+    "\n",
+    "files_and_dirs = Path(\"/Users/scovitz/BOnD/bond/testdata/complete/\").rglob('*')\n",
+    "for path in files_and_dirs:\n",
+    "    old_name = path.stem\n",
+    "    old_ext = path.suffix\n",
+    "    directory = path.parent\n",
+    "    new_name = old_name.replace(\"T2w\", \"T1w\") + old_ext\n",
+    "    path.rename(Path(directory, new_name))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 6/6 [00:00<00:00, 278.28it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# generating csvs\n",
+    "\n",
+    "bod = BOnD(data_root2)\n",
+    "bod._cache_fieldmaps()\n",
+    "out = bod.get_CSVs('/Users/scovitz/BOnD/notebooks/NewTests/')\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,19 +108,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['datatype-anat_reconstruction-refaced_suffix-T1w', 'datatype-func_run-1_suffix-bold_task-rest', 'datatype-func_run-2_suffix-bold_task-rest']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "bod = BOnD(data_root2)\n",
     "key_groups = bod.get_key_groups()\n",
@@ -69,17 +121,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "190\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "files = bod.get_filenames('datatype-func_run-2_suffix-bold_task-rest')\n",
     "files\n",
@@ -89,22 +133,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "datatype-anat_reconstruction-refaced_suffix-T1w\n",
-      "191\n",
-      "datatype-func_run-1_suffix-bold_task-rest\n",
-      "191\n",
-      "datatype-func_run-2_suffix-bold_task-rest\n",
-      "190\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "\n",
     "for key_group in key_groups:\n",
@@ -169,18 +200,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest003/ses-1/func/sub-colornest003_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest004/ses-1/func/sub-colornest004_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest005/ses-1/func/sub-colornest005_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest007/ses-1/func/sub-colornest007_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest008/ses-1/func/sub-colornest008_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest013/ses-1/func/sub-colornest013_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest015/ses-1/func/sub-colornest015_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest016/ses-1/func/sub-colornest016_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest023/ses-1/func/sub-colornest023_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest026/ses-1/func/sub-colornest026_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest027/ses-1/func/sub-colornest027_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest029/ses-1/func/sub-colornest029_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest032/ses-1/func/sub-colornest032_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest033/ses-1/func/sub-colornest033_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest041/ses-1/func/sub-colornest041_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest045/ses-1/func/sub-colornest045_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest047/ses-1/func/sub-colornest047_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest049/ses-1/func/sub-colornest049_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest052/ses-1/func/sub-colornest052_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest053/ses-1/func/sub-colornest053_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest056/ses-1/func/sub-colornest056_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest059/ses-1/func/sub-colornest059_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest061/ses-1/func/sub-colornest061_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest063/ses-1/func/sub-colornest063_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest064/ses-1/func/sub-colornest064_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest066/ses-1/func/sub-colornest066_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest067/ses-1/func/sub-colornest067_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest070/ses-1/func/sub-colornest070_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest071/ses-1/func/sub-colornest071_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest073/ses-1/func/sub-colornest073_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest074/ses-1/func/sub-colornest074_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest077/ses-1/func/sub-colornest077_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest080/ses-1/func/sub-colornest080_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest085/ses-1/func/sub-colornest085_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest086/ses-1/func/sub-colornest086_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest087/ses-1/func/sub-colornest087_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest088/ses-1/func/sub-colornest088_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest090/ses-1/func/sub-colornest090_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest093/ses-1/func/sub-colornest093_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest095/ses-1/func/sub-colornest095_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest098/ses-1/func/sub-colornest098_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest106/ses-1/func/sub-colornest106_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest107/ses-1/func/sub-colornest107_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest110/ses-1/func/sub-colornest110_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest111/ses-1/func/sub-colornest111_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest113/ses-1/func/sub-colornest113_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest114/ses-1/func/sub-colornest114_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest115/ses-1/func/sub-colornest115_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest116/ses-1/func/sub-colornest116_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest117/ses-1/func/sub-colornest117_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest120/ses-1/func/sub-colornest120_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest125/ses-1/func/sub-colornest125_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest127/ses-1/func/sub-colornest127_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest130/ses-1/func/sub-colornest130_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest131/ses-1/func/sub-colornest131_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest133/ses-1/func/sub-colornest133_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest143/ses-1/func/sub-colornest143_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest144/ses-1/func/sub-colornest144_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest147/ses-1/func/sub-colornest147_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest148/ses-1/func/sub-colornest148_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest152/ses-1/func/sub-colornest152_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest154/ses-1/func/sub-colornest154_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest155/ses-1/func/sub-colornest155_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest159/ses-1/func/sub-colornest159_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest161/ses-1/func/sub-colornest161_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest169/ses-1/func/sub-colornest169_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest173/ses-1/func/sub-colornest173_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest175/ses-1/func/sub-colornest175_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest177/ses-1/func/sub-colornest177_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest182/ses-1/func/sub-colornest182_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest184/ses-1/func/sub-colornest184_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest194/ses-1/func/sub-colornest194_ses-1_task-rest_run-02_bold.nii.gz'), PosixPath('/Users/Covitz/Downloads/RBC_growupCCNP_BIDS/sub-colornest195/ses-1/func/sub-colornest195_ses-1_task-rest_run-02_bold.nii.gz')]\n",
-      "73\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# TESTING THE change_filename method!\n",
     "key_group = 'datatype-func_run-2_suffix-bold_task-rest'\n",


### PR DESCRIPTION

Robustly apply changes from a user-edited summary CSV to a BIDS dataset, with everything tracked in Datalad

## TODO

 - [x] Add function that writes bash scripts for moving (renaming) files
 - [x] Add a CLI entrypoint for ^
 - [x] Write a test for this workflow