### PR TITLE
Fix mod count sorting

### DIFF
--- a/bond/bond.py
+++ b/bond/bond.py
@@ -11,7 +11,6 @@ from bids.utils import listify
 import numpy as np
 import pandas as pd
 import nibabel as nb
-# import pdb
 import datalad.api as dlapi
 from shutil import copytree, copyfile
 from tqdm import tqdm
@@ -637,7 +636,7 @@ class BOnD(object):
 
         ret = _get_param_groups(
             to_include, self.layout, self.fieldmap_lookup, key_group,
-            self.grouping_config, modality)
+            self.grouping_config, modality, self.keys_files)
 
         return ret
 
@@ -821,11 +820,6 @@ class BOnD(object):
 
                 self.keys_files[ret].append(path)
 
-        # sort the key_groups by count
-        # ordered = sorted(self.keys_files, key=lambda k:
-        #                  len(self.keys_files[k]), reverse=True)
-        # pdb.set_trace()
-        # return ordered
         return sorted(key_groups)
 
     def change_metadata(self, filters, pattern, metadata):
@@ -938,7 +932,7 @@ def _get_intended_for_reference(scan):
 
 
 def _get_param_groups(files, layout, fieldmap_lookup, key_group_name,
-                      grouping_config, modality):
+                      grouping_config, modality, keys_files):
 
     """Finds a list of *parameter groups* from a list of files.
 
@@ -1045,6 +1039,9 @@ def _get_param_groups(files, layout, fieldmap_lookup, key_group_name,
     # add the modality as a column
     deduped["Modality"] = modality
 
+    # add key group count column (will delete later)
+    deduped["KeyGroupCount"] = len(keys_files[key_group_name])
+
     # Add the ParamGroup to the whole list of files
     labeled_files = pd.merge(df, deduped, on=param_group_cols)
     value_counts = labeled_files.ParamGroup.value_counts()
@@ -1069,6 +1066,8 @@ def _get_param_groups(files, layout, fieldmap_lookup, key_group_name,
     # sort ordered_labeled_files by param group
     ordered_labeled_files.sort_values(by=['Counts'], inplace=True,
                                       ascending=False)
+
+    # pdb.set_trace()
 
     return ordered_labeled_files, param_groups_with_counts
 

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -788,8 +788,10 @@ class BOnD(object):
 
         big_df, summary = self.get_param_groups_dataframes()
 
-        # summary = summary.sort_values(by=['Modality'])
-        # big_df = big_df.sort_values(by=['Modality'])
+        summary = summary.sort_values(by=['Modality', 'KeyGroupCount'],
+                                      ascending=[True, False])
+        big_df = big_df.sort_values(by=['Modality', 'KeyGroupCount'],
+                                    ascending=[True, False])
 
         big_df.to_csv(path_prefix + "_files.csv", index=False)
         summary.to_csv(path_prefix + "_summary.csv", index=False)

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -789,8 +789,8 @@ class BOnD(object):
 
         big_df, summary = self.get_param_groups_dataframes()
 
-        summary = summary.sort_values(by=['Modality'])
-        big_df = big_df.sort_values(by=['Modality'])
+        # summary = summary.sort_values(by=['Modality'])
+        # big_df = big_df.sort_values(by=['Modality'])
 
         big_df.to_csv(path_prefix + "_files.csv", index=False)
         summary.to_csv(path_prefix + "_summary.csv", index=False)

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -822,12 +822,11 @@ class BOnD(object):
                 self.keys_files[ret].append(path)
 
         # sort the key_groups by count
-        ordered = sorted(self.keys_files, key=lambda k:
-                         len(self.keys_files[k]), reverse=True)
+        # ordered = sorted(self.keys_files, key=lambda k:
+        #                  len(self.keys_files[k]), reverse=True)
         # pdb.set_trace()
-        #return ordered
+        # return ordered
         return sorted(key_groups)
-
 
     def change_metadata(self, filters, pattern, metadata):
 

--- a/bond/bond.py
+++ b/bond/bond.py
@@ -11,6 +11,7 @@ from bids.utils import listify
 import numpy as np
 import pandas as pd
 import nibabel as nb
+# import pdb
 import datalad.api as dlapi
 from shutil import copytree, copyfile
 from tqdm import tqdm
@@ -804,9 +805,12 @@ class BOnD(object):
         # reset self.keys_files
         self.keys_files = {}
 
+        key_groups = set()
+
         for path in Path(self.path).rglob("sub-*/**/*.*"):
 
             if str(path).endswith(".nii") or str(path).endswith(".nii.gz"):
+                key_groups.update((_file_to_key_group(path),))
 
                 # Fill the dictionary of key group, list of filenames pairrs
                 ret = _file_to_key_group(path)
@@ -820,9 +824,10 @@ class BOnD(object):
         # sort the key_groups by count
         ordered = sorted(self.keys_files, key=lambda k:
                          len(self.keys_files[k]), reverse=True)
+        # pdb.set_trace()
+        #return ordered
+        return sorted(key_groups)
 
-        # return sorted(key_groups)
-        return ordered
 
     def change_metadata(self, filters, pattern, metadata):
 

--- a/tests/test_bond.py
+++ b/tests/test_bond.py
@@ -478,7 +478,7 @@ def test_keygroups(tmp_path):
 
     # Test that the correct key groups are found
     key_groups = complete_bod.get_key_groups()
-    assert set(key_groups) == set(COMPLETE_KEY_GROUPS)
+    assert key_groups == COMPLETE_KEY_GROUPS
 
     # Test the incomplete
     ibod = BOnD(data_root / "inconsistent")
@@ -487,7 +487,7 @@ def test_keygroups(tmp_path):
 
     # There will still be the same number of key groups
     ikey_groups = ibod.get_key_groups()
-    assert set(ikey_groups) == set(COMPLETE_KEY_GROUPS)
+    assert ikey_groups == COMPLETE_KEY_GROUPS
 
 
 def test_csv_creation(tmp_path):
@@ -503,7 +503,7 @@ def test_csv_creation(tmp_path):
 
     # Test that the correct key groups are found
     key_groups = complete_bod.get_key_groups()
-    assert set(key_groups) == set(COMPLETE_KEY_GROUPS)
+    assert key_groups == COMPLETE_KEY_GROUPS
 
     # Get the CSVs from the complete data
     cfiles_df, csummary_df = \
@@ -534,7 +534,7 @@ def test_csv_creation(tmp_path):
 
     # There will still be the same number of key groups
     ikey_groups = ibod.get_key_groups()
-    assert set(ikey_groups) == set(COMPLETE_KEY_GROUPS)
+    assert ikey_groups == COMPLETE_KEY_GROUPS
 
     # Get the CSVs from the inconsistent data
     ifiles_df, isummary_df = \


### PR DESCRIPTION
sort within modality by key group count without messing up order of param groups

make work for both pre and post apply changes